### PR TITLE
adding filter for only most recent data

### DIFF
--- a/models/current season/raw/current_rosters.sql
+++ b/models/current season/raw/current_rosters.sql
@@ -1,5 +1,8 @@
+WITH cte_current_batch AS (
+    SELECT max(_sdc_batched_at) as batch_date
+    FROM {{ source( 'current_season', 'rosters' ) }}
+)
 SELECT * 
 FROM {{ source( 'current_season', 'rosters' ) }}
-
---contemplated splitting rosters here but need to enrich all players with data first
---WHERE STATUS <> 'FA'
+JOIN cte_current_batch ON 1=1
+WHERE _sdc_batched_at = batch_date


### PR DESCRIPTION
meltano spreadsheets-anywhere tap is having an issue with defining primary keys, so adding code to only look at the most recent batch.